### PR TITLE
[FIX] Start db container before circleci tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - sudo apt-get install -qq ansible
     - sudo pip install 'docker-compose<1.3' 'requests==2.5.3'
     - docker-compose build
+    - docker-compose up -d postgres && sleep 3;
 test:
   override:
     - docker-compose run webapp npm test


### PR DESCRIPTION
Re-adding this since circleci is periodically failing with "Unable to connect to database"